### PR TITLE
fix/improve: lazy.nvim installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Use your favorite plugin manager. For example, with here is how you can install 
 ```lua
 {
 	"kungfusheep/snipe-lsp.nvim",
+	event = "VeryLazy",
 	dependencies = "leath-dub/snipe.nvim",
 	opts = {},
-	cmd = { "SnipeLspSymbols", "SnipeLspSymbolsSplit", "SnipeLspSymbolsVSplit" },
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,11 @@ Use your favorite plugin manager. For example, with here is how you can install 
 
 ```lua
 {
-    'kungfusheep/snipe-lsp',
-    dependencies = {
-        'leath-dub/snipe.nvim'
-    },
-    config = function()
-        require'snipe-lsp'.setup()
-    end
-}
+	"kungfusheep/snipe-lsp.nvim",
+	dependencies = "leath-dub/snipe.nvim",
+	opts = {},
+	cmd = { "SnipeLspSymbols", "SnipeLspSymbolsSplit", "SnipeLspSymbolsVSplit" },
+},
 ```
 
 


### PR DESCRIPTION
- fixes repo (was missing the trailing `.nvim`)
- adds missing trailing comma
- enables lazy-loading
- use `opts` key as recommended by lazy.nvim